### PR TITLE
タスクパズルのタスク編集機能

### DIFF
--- a/app/assets/javascripts/puzzle.js
+++ b/app/assets/javascripts/puzzle.js
@@ -1,14 +1,5 @@
 $(document).on("turbolinks:load", function() {
 
-  $('#task-modal-show').on('click', function(){
-    $('.task-modal').fadeIn(250);
-  })
-
-  $('#modal-close').on('click', function(){
-    $('.task-modal').fadeOut(250);
-  })
-
-
   const image = new Image();
   image.onload = function(e){
     const canvas = document.getElementById("stage");

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,6 +24,7 @@
 @import "events/event.new";
 @import "events/event.form";
 @import "puzzles/index";
+@import "puzzles/edit";
 
 @import "font-awesome-sprockets";
 @import "font-awesome";

--- a/app/assets/stylesheets/puzzles/_edit.scss
+++ b/app/assets/stylesheets/puzzles/_edit.scss
@@ -2,7 +2,7 @@
   position: absolute;
   top: 0;
   left: 18%;
-  height: 50%;
+  height: 40%;
   margin:100px auto 0;
   width: 70%;
   border: 2px solid $color3;
@@ -16,5 +16,31 @@
     font-size: 30px;
     margin-bottom: 30px;
   }
+  &--unit{
+    padding: 30px;
+  }
 }
 
+.puzzle__form--label{
+  font-size: 28px;
+}
+
+.puzzle__form--title--input{
+  font-size: 24px;
+  width: 100%;
+  padding:6px;
+}
+
+.puzzle__form--btn{
+  background-color: $color4;
+  text-decoration: none;
+  color: black;
+  border: 1px solid black;
+  box-shadow: 2px 2px #03f;
+  cursor: pointer;
+  border-radius: 3px;
+  display: inline-block;
+  padding: 8px 18px;
+  margin-top: 20px;
+  left: 0;
+}

--- a/app/assets/stylesheets/puzzles/_edit.scss
+++ b/app/assets/stylesheets/puzzles/_edit.scss
@@ -14,5 +14,7 @@
     text-align: center;
     line-height: 60px;
     font-size: 30px;
+    margin-bottom: 30px;
   }
 }
+

--- a/app/assets/stylesheets/puzzles/_edit.scss
+++ b/app/assets/stylesheets/puzzles/_edit.scss
@@ -1,0 +1,11 @@
+.task--puzzle__edit{
+  position: absolute;
+  top: 0;
+  left: 18%;
+  height: 50%;
+  margin:100px auto 0;
+  width: 70%;
+  border: 2px solid $color3;
+  box-shadow: 4px 4px $color4;
+  background-color: $color2;
+}

--- a/app/assets/stylesheets/puzzles/_edit.scss
+++ b/app/assets/stylesheets/puzzles/_edit.scss
@@ -8,4 +8,11 @@
   border: 2px solid $color3;
   box-shadow: 4px 4px $color4;
   background-color: $color2;
+  &--header{
+    border-bottom: 1px solid $color3;
+    height: 60px;
+    text-align: center;
+    line-height: 60px;
+    font-size: 30px;
+  }
 }

--- a/app/assets/stylesheets/puzzles/_index.scss
+++ b/app/assets/stylesheets/puzzles/_index.scss
@@ -26,22 +26,6 @@
   position: relative;
 }
 
-.task__edit{
-  margin-left: 30px;
-  line-height: 65px;
-  font-size: 18px;
-}
-
-.task__edit--link{
-  display: inline;
-  cursor: pointer;
-}
-
-.task__edit--link:hover{
-  transition: all 0.3s ease 0s;
-  border-bottom: 3px solid #0066FF;
-}
-
 .task__index{
   background-color: $color3;
   width: 540px;
@@ -50,6 +34,19 @@
   left: calc(12% + 30px);
   top: 115px;
   border: 3px groove $color4;
+  &--edit{
+    display: inline-block;
+    border-bottom: 1px solid blue;
+    margin-left: 80px;
+    &--link{
+      text-decoration: none;
+      color: black; 
+      transition: all 0.3s ease 0s;
+    }
+    &--link:hover{
+      color: #4689FF;
+    }
+  }
   &--unit1{
     @include task-box;
   }

--- a/app/assets/stylesheets/puzzles/_index.scss
+++ b/app/assets/stylesheets/puzzles/_index.scss
@@ -114,60 +114,6 @@
   }
 }
 
-.task-modal{
-  box-shadow: 0 0 0 9999px rgba(0, 0, 0, .6);
-  display: none;
-  background-color: #fff;
-  z-index: 100;
-  position: absolute;
-  top: 0;
-  right: 100px;
-  width: 540px;
-  height: 653px;
-  border-radius: 10px;
-  border: 5px solid #3366FF;
-  &__title{
-    background-color: $color2;
-    height: 50px;
-    border-bottom: 1px solid silver;
-    display: flex;
-    align-items: center;
-    &--text{
-      margin: 0 auto;
-      font-size: 20px;
-    }
-  }
-  &__edit{
-    height: 60px;
-    border-bottom: 1px solid silver;
-    display: flex;
-    align-items: center;
-    padding:3px 0;
-  }
-  &__edit p{
-    font-size: 20px;
-    line-height: 60px;
-    padding-left: 5px;
-  }
-  &__input{
-    border-radius: 4px;
-    margin-left: 10px;
-    height: 30px;
-    font-size: 20px;
-    width: 370px;
-  }
-  &__btn{
-    margin-left: 10px;
-    padding: 20px;
-  }
-}
-
-#modal-close{
-  margin-right: 10px;
-  color: red;
-  cursor: pointer;
-}
-
 /*チェックボタン始まり*/
 .round {
   position: relative;

--- a/app/assets/stylesheets/puzzles/_index.scss
+++ b/app/assets/stylesheets/puzzles/_index.scss
@@ -50,54 +50,63 @@
     }
   }
   &--unit1{
+    position: relative;
     @include task-box;
   }
   &--unit1 p{
     @include task-show;
   }
   &--unit2{
+    position: relative;
     @include task-box;
   }
   &--unit2 p{
     @include task-show;
   }
   &--unit3{
+    position: relative;
     @include task-box;
   }
   &--unit3 p{
     @include task-show;
   }
   &--unit4{
+    position: relative;
     @include task-box;
   }
   &--unit4 p{
     @include task-show;
   }
   &--unit5{
+    position: relative;
     @include task-box;
   }
   &--unit5 p{
     @include task-show;
   }
   &--unit6{
+    position: relative;
     @include task-box;
   }
   &--unit6 p{
     @include task-show;
   }
   &--unit7{
+    position: relative;
     @include task-box;
   }
   &--unit7 p{
     @include task-show;
   }
   &--unit8{
+    position: relative;
     @include task-box;
   }
   &--unit8 p{
     @include task-show;
   }
   &--unit9{
+    position: relative;
     @include task-box;
   }
   &--unit9 p{

--- a/app/assets/stylesheets/puzzles/_index.scss
+++ b/app/assets/stylesheets/puzzles/_index.scss
@@ -36,12 +36,14 @@
   border: 3px groove $color4;
   &--edit{
     display: inline-block;
-    border-bottom: 1px solid blue;
-    margin-left: 80px;
     &--link{
+      border-bottom: 1px solid blue;
       text-decoration: none;
       color: black; 
       transition: all 0.3s ease 0s;
+      position: absolute;
+      right: 50px;
+      top: 18px;
     }
     &--link:hover{
       color: #4689FF;

--- a/app/controllers/puzzles_controller.rb
+++ b/app/controllers/puzzles_controller.rb
@@ -10,6 +10,7 @@ class PuzzlesController < ApplicationController
           Puzzle.create(user_id: @user.id)
         end
       end
+      @puzzle = @puzzles.first
     end
   end
 

--- a/app/controllers/puzzles_controller.rb
+++ b/app/controllers/puzzles_controller.rb
@@ -14,6 +14,7 @@ class PuzzlesController < ApplicationController
   end
 
   def edit
+    @user = User.find(params[:user_id])
     @puzzle = Puzzle.find(params[:id])
   end
   

--- a/app/controllers/puzzles_controller.rb
+++ b/app/controllers/puzzles_controller.rb
@@ -10,12 +10,11 @@ class PuzzlesController < ApplicationController
           Puzzle.create(user_id: @user.id)
         end
       end
-      # @puzzle = @puzzles.first
     end
   end
 
   def edit
-    @puzzles = Puzzle.where(user_id: current_user)
+    @puzzle = Puzzle.find(params[:id])
   end
   
   def create

--- a/app/controllers/puzzles_controller.rb
+++ b/app/controllers/puzzles_controller.rb
@@ -4,8 +4,13 @@ class PuzzlesController < ApplicationController
     @user = User.find(params[:user_id])
     if user_signed_in?
       @puzzles = Puzzle.where(user_id: current_user)
+
+      if @puzzles == []
+        9.times do
+          Puzzle.create(user_id: @user.id)
+        end
+      end
     end
-    is_puzzle?
   end
 
   def create

--- a/app/controllers/puzzles_controller.rb
+++ b/app/controllers/puzzles_controller.rb
@@ -34,7 +34,7 @@ class PuzzlesController < ApplicationController
   
 private
   def puzzle_params
-    params.permit(:task).merge(user_id: current_user.id)
+    params.require(:puzzle).permit(:task).merge(user_id: current_user.id)
   end
   
 end

--- a/app/controllers/puzzles_controller.rb
+++ b/app/controllers/puzzles_controller.rb
@@ -16,6 +16,7 @@ class PuzzlesController < ApplicationController
   def edit
     @user = User.find(params[:user_id])
     @puzzle = Puzzle.find(params[:id])
+    
   end
   
   def create

--- a/app/controllers/puzzles_controller.rb
+++ b/app/controllers/puzzles_controller.rb
@@ -17,6 +17,15 @@ class PuzzlesController < ApplicationController
     @puzzle = Puzzle.create(puzzle_params)
     redirect_to user_puzzles_path(current_user)
   end
+
+  def update
+    @puzzle = Puzzle.find(params[:id])
+    if @puzzle.update(puzzle_params)
+      redirect_to user_puzzles_path(current_user)
+    else
+      render :index
+    end
+  end
   
 private
   def puzzle_params

--- a/app/controllers/puzzles_controller.rb
+++ b/app/controllers/puzzles_controller.rb
@@ -10,10 +10,14 @@ class PuzzlesController < ApplicationController
           Puzzle.create(user_id: @user.id)
         end
       end
-      @puzzle = @puzzles.first
+      # @puzzle = @puzzles.first
     end
   end
 
+  def edit
+    @puzzles = Puzzle.where(user_id: current_user)
+  end
+  
   def create
     @puzzle = Puzzle.create(puzzle_params)
     redirect_to user_puzzles_path(current_user)

--- a/app/controllers/puzzles_controller.rb
+++ b/app/controllers/puzzles_controller.rb
@@ -5,6 +5,7 @@ class PuzzlesController < ApplicationController
     if user_signed_in?
       @puzzles = Puzzle.where(user_id: current_user)
     end
+    is_puzzle?
   end
 
   def create

--- a/app/controllers/puzzles_controller.rb
+++ b/app/controllers/puzzles_controller.rb
@@ -16,7 +16,6 @@ class PuzzlesController < ApplicationController
   def edit
     @user = User.find(params[:user_id])
     @puzzle = Puzzle.find(params[:id])
-    
   end
   
   def create
@@ -29,7 +28,7 @@ class PuzzlesController < ApplicationController
     if @puzzle.update(puzzle_params)
       redirect_to user_puzzles_path(current_user)
     else
-      render :index
+      render :edit
     end
   end
   

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,10 +18,8 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     if @user.update(user_params)
       redirect_to user_events_path(current_user)
-
     else
       render :edit
-
     end
   end
 

--- a/app/models/puzzle.rb
+++ b/app/models/puzzle.rb
@@ -1,10 +1,10 @@
 class Puzzle < ApplicationRecord
   belongs_to :user
 
-  def is_puzzle?
+  def self.is_puzzle?
     if @puzzles == nil
-      9.times do 
-        Puzzle.new
+      9.times do
+        Puzzle.create(user_id: @user.id)
       end
     end
   end

--- a/app/models/puzzle.rb
+++ b/app/models/puzzle.rb
@@ -1,12 +1,4 @@
 class Puzzle < ApplicationRecord
   belongs_to :user
 
-  def self.is_puzzle?
-    if @puzzles == nil
-      9.times do
-        Puzzle.create(user_id: @user.id)
-      end
-    end
-  end
-
 end

--- a/app/models/puzzle.rb
+++ b/app/models/puzzle.rb
@@ -2,5 +2,11 @@ class Puzzle < ApplicationRecord
   belongs_to :user
 
   def is_puzzle?
+    if @puzzles == nil
+      9.times do 
+        Puzzle.new
+      end
+    end
   end
+
 end

--- a/app/models/puzzle.rb
+++ b/app/models/puzzle.rb
@@ -1,3 +1,6 @@
 class Puzzle < ApplicationRecord
   belongs_to :user
+
+  def is_puzzle?
+  end
 end

--- a/app/views/puzzles/edit.html.haml
+++ b/app/views/puzzles/edit.html.haml
@@ -11,4 +11,5 @@
         = link_to "タスクパズル", user_puzzles_path(current_user), class: "user--info__edit"
 
 .task--puzzle__edit
-  %p.task--puzzle__edit--title タスクパズルの編集
+  .task--puzzle__edit--header
+    %p タスクパズルの編集

--- a/app/views/puzzles/edit.html.haml
+++ b/app/views/puzzles/edit.html.haml
@@ -10,6 +10,3 @@
         = link_to "タスクの追加", new_user_event_path(current_user), class: "user--info__edit"
         = link_to "タスクパズル", user_puzzles_path(current_user), class: "user--info__edit"
 
-.puzzle__menu
-  .task__edit
-    %p.task__edit--link#task-modal-show タスクの編集

--- a/app/views/puzzles/edit.html.haml
+++ b/app/views/puzzles/edit.html.haml
@@ -12,10 +12,10 @@
 
 .task--puzzle__edit
   %p.task--puzzle__edit--header タスクパズルの編集
-  %p.task--puzzle__edit--unit
-  = form_for @puzzle, url: user_puzzle_path do |f|
-    .field.puzzle__form--field
-      = f.label :タスク：, class: "puzzle__form--label"
-      = f.text_field :task, class: "puzzle__form--title--input"
-    .actions
-      = f.submit '編集', class: "event__form--btn"
+  .task--puzzle__edit--unit
+    = form_for @puzzle, url: user_puzzle_path do |f|
+      .field.puzzle__form--field
+        = f.label :タスク：, class: "puzzle__form--label"
+        = f.text_field :task, class: "puzzle__form--title--input"
+      .actions
+        = f.submit '編集', class: "puzzle__form--btn"

--- a/app/views/puzzles/edit.html.haml
+++ b/app/views/puzzles/edit.html.haml
@@ -14,6 +14,12 @@
   %p.task--puzzle__edit--header タスクパズルの編集
   .task--puzzle__edit--unit
     = form_for @puzzle, url: user_puzzle_path do |f|
+      - if @puzzle.errors.any?
+        #error_explanation
+          %ul
+            - @puzzle.errors.full_messages.each do |message|
+              %li= message
+
       .field.puzzle__form--field
         = f.label :タスク：, class: "puzzle__form--label"
         = f.text_field :task, class: "puzzle__form--title--input"

--- a/app/views/puzzles/edit.html.haml
+++ b/app/views/puzzles/edit.html.haml
@@ -1,0 +1,15 @@
+.user__menu
+  .user--info
+    .user--info__image
+      = image_tag @user.image.url, class: 'icon_image', alt: 'default.png'
+    
+    .user--info__name
+      %p= @user.nickname
+      -if user_signed_in? && @user.id == current_user.id
+        = link_to "プロフィール編集", edit_user_path(current_user), class: "user--info__edit", method: :get
+        = link_to "タスクの追加", new_user_event_path(current_user), class: "user--info__edit"
+        = link_to "タスクパズル", user_puzzles_path(current_user), class: "user--info__edit"
+
+.puzzle__menu
+  .task__edit
+    %p.task__edit--link#task-modal-show タスクの編集

--- a/app/views/puzzles/edit.html.haml
+++ b/app/views/puzzles/edit.html.haml
@@ -11,5 +11,6 @@
         = link_to "タスクパズル", user_puzzles_path(current_user), class: "user--info__edit"
 
 .task--puzzle__edit
-  .task--puzzle__edit--header
-    %p タスクパズルの編集
+  %p.task--puzzle__edit--header タスクパズルの編集
+  .task--puzzle__edit--unit
+    = "タスク#{}:"

--- a/app/views/puzzles/edit.html.haml
+++ b/app/views/puzzles/edit.html.haml
@@ -13,7 +13,7 @@
 .task--puzzle__edit
   %p.task--puzzle__edit--header タスクパズルの編集
   .task--puzzle__edit--unit
-    = form_for @puzzle, url: user_puzzle_path do |f|
+    = form_for @puzzle, url: user_puzzle_path, method: :patch do |f|
       - if @puzzle.errors.any?
         #error_explanation
           %ul

--- a/app/views/puzzles/edit.html.haml
+++ b/app/views/puzzles/edit.html.haml
@@ -10,3 +10,5 @@
         = link_to "タスクの追加", new_user_event_path(current_user), class: "user--info__edit"
         = link_to "タスクパズル", user_puzzles_path(current_user), class: "user--info__edit"
 
+.task--puzzle__edit
+  %p.task--puzzle__edit--title タスクパズルの編集

--- a/app/views/puzzles/edit.html.haml
+++ b/app/views/puzzles/edit.html.haml
@@ -12,5 +12,10 @@
 
 .task--puzzle__edit
   %p.task--puzzle__edit--header タスクパズルの編集
-  .task--puzzle__edit--unit
-    = "タスク#{}:"
+  %p.task--puzzle__edit--unit
+  = form_for @puzzle, url: user_puzzle_path do |f|
+    .field.puzzle__form--field
+      = f.label :タスク：, class: "puzzle__form--label"
+      = f.text_field :task, class: "puzzle__form--title--input"
+    .actions
+      = f.submit '編集', class: "event__form--btn"

--- a/app/views/puzzles/index.html.haml
+++ b/app/views/puzzles/index.html.haml
@@ -10,9 +10,6 @@
         = link_to "タスクの追加", new_user_event_path(current_user), class: "user--info__edit"
         = link_to "タスクパズル", user_puzzles_path(current_user), class: "user--info__edit"
 
-.puzzle__menu
-  .task__edit
-    %p.task__edit--link#task-modal-show タスクの編集
 
 .task-modal
   .task-modal__title

--- a/app/views/puzzles/index.html.haml
+++ b/app/views/puzzles/index.html.haml
@@ -19,59 +19,61 @@
     %p.task-modal__title--text タスクを入力してください
     .fas.fa-window-close.fa-lg#modal-close
 
-  .task-modal__edit
-    %p タスク1
-    = form_with(model: @puzzle, local: true, id: "input-task-1") do |f|
-      = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-      = f.submit '決定',id:"task-btn-1" , class:"task-modal__btn"
 
-  .task-modal__edit
-    %p タスク2
-    = form_with(model: @puzzle, local: true, id: "input-task-2") do |f|
-      = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-      = f.submit '決定',id:"task-btn-2" , class:"task-modal__btn"
+  - @puzzles.each do |puzzle|
+    .task-modal__edit
+      %p タスク1
+      = form_for model: puzzle, url: user_puzzle_path do |f|
+        = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
+        = f.submit '決定',id:"task-btn-1" , class:"task-modal__btn"
 
-  .task-modal__edit
-    %p タスク3
-    = form_with(model: @puzzle, local: true, id: "input-task-3") do |f|
-      = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-      = f.submit '決定',id:"task-btn-3" , class:"task-modal__btn"
+  -# .task-modal__edit
+  -#   %p タスク2
+  -#   = form_with(model: @puzzle, local: true, id: "input-task-2") do |f|
+  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
+  -#     = f.submit '決定',id:"task-btn-2" , class:"task-modal__btn"
 
-  .task-modal__edit
-    %p タスク4
-    = form_with(model: @puzzle, local: true, id: "input-task-4") do |f|
-      = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-      = f.submit '決定',id:"task-btn-4" , class:"task-modal__btn"
+  -# .task-modal__edit
+  -#   %p タスク3
+  -#   = form_with(model: @puzzle, local: true, id: "input-task-3") do |f|
+  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
+  -#     = f.submit '決定',id:"task-btn-3" , class:"task-modal__btn"
 
-  .task-modal__edit
-    %p タスク5
-    = form_with(model: @puzzle, local: true, id: "input-task-5") do |f|
-      = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-      = f.submit '決定',id:"task-btn-5" , class:"task-modal__btn"
+  -# .task-modal__edit
+  -#   %p タスク4
+  -#   = form_with(model: @puzzle, local: true, id: "input-task-4") do |f|
+  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
+  -#     = f.submit '決定',id:"task-btn-4" , class:"task-modal__btn"
 
-  .task-modal__edit
-    %p タスク6
-    = form_with(model: @puzzle, local: true, id: "input-task-6") do |f|
-      = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-      = f.submit '決定',id:"task-btn-6" , class:"task-modal__btn"
+  -# .task-modal__edit
+  -#   %p タスク5
+  -#   = form_with(model: @puzzle, local: true, id: "input-task-5") do |f|
+  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
+  -#     = f.submit '決定',id:"task-btn-5" , class:"task-modal__btn"
 
-  .task-modal__edit
-    %p タスク7
-    = form_with(model: @puzzle, local: true, id: "input-task-7") do |f|
-      = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-      = f.submit '決定',id:"task-btn-7" , class:"task-modal__btn"
+  -# .task-modal__edit
+  -#   %p タスク6
+  -#   = form_with(model: @puzzle, local: true, id: "input-task-6") do |f|
+  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
+  -#     = f.submit '決定',id:"task-btn-6" , class:"task-modal__btn"
 
-  .task-modal__edit
-    %p タスク8
-    = form_with(model: @puzzle, local: true, id: "input-task-8") do |f|
-      = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-      = f.submit '決定',id:"task-btn-8" , class:"task-modal__btn"
+  -# .task-modal__edit
+  -#   %p タスク7
+  -#   = form_with(model: @puzzle, local: true, id: "input-task-7") do |f|
+  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
+  -#     = f.submit '決定',id:"task-btn-7" , class:"task-modal__btn"
 
-  .task-modal__edit
-    %p タスク9
-    = form_with(model: @puzzle, local: true, id: "input-task-9") do |f|
-      = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-      = f.submit '決定',id:"task-btn-9" , class:"task-modal__btn"
+  -# .task-modal__edit
+  -#   %p タスク8
+  -#   = form_with(model: @puzzle, local: true, id: "input-task-8") do |f|
+  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
+  -#     = f.submit '決定',id:"task-btn-8" , class:"task-modal__btn"
+
+  -# .task-modal__edit
+  -#   %p タスク9
+  -#   = form_with(model: @puzzle, local: true, id: "input-task-9") do |f|
+  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
+  -#     = f.submit '決定',id:"task-btn-9" , class:"task-modal__btn"
 
 .task__index
   .task__index--unit1

--- a/app/views/puzzles/index.html.haml
+++ b/app/views/puzzles/index.html.haml
@@ -20,12 +20,13 @@
     .fas.fa-window-close.fa-lg#modal-close
 
 
-  -# - @puzzles.each do |puzzle|
-  .task-modal__edit
-    %p タスク1
-    = form_with(model: @puzzle, url: user_puzzle_path, method: :patch) do |f|
-      = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-      = f.submit '決定',id:"task-btn-1" , class:"task-modal__btn"
+  - @puzzles.each do |puzzle|
+    .task-modal__edit
+      %p タスク1
+      -# = form_for("/users/#{current_user.id}/puzzles/#{puzzle.id}", id: "input-task-1",method: :put) do |f|
+      = form_with(model:[current_user, puzzle]) do |f|
+        = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
+        = f.submit '決定',id:"task-btn-1" , class:"task-modal__btn"
 
   -# .task-modal__edit
   -#   %p タスク2

--- a/app/views/puzzles/index.html.haml
+++ b/app/views/puzzles/index.html.haml
@@ -10,14 +10,6 @@
         = link_to "タスクの追加", new_user_event_path(current_user), class: "user--info__edit"
         = link_to "タスクパズル", user_puzzles_path(current_user), class: "user--info__edit"
 
-
-.task-modal
-  .task-modal__title
-    %p.task-modal__title--text タスクを入力してください
-    .fas.fa-window-close.fa-lg#modal-close
-
-
-
 .task__index
   .task__index--unit1
     %p タスク1:

--- a/app/views/puzzles/index.html.haml
+++ b/app/views/puzzles/index.html.haml
@@ -17,61 +17,6 @@
     .fas.fa-window-close.fa-lg#modal-close
 
 
-  - @puzzles.each do |puzzle|
-    .task-modal__edit
-      %p タスク1
-      -# = form_for("/users/#{current_user.id}/puzzles/#{puzzle.id}", id: "input-task-1",method: :put) do |f|
-      = form_with(model:[current_user, puzzle]) do |f|
-        = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-        = f.submit '決定',id:"task-btn-1" , class:"task-modal__btn"
-
-  -# .task-modal__edit
-  -#   %p タスク2
-  -#   = form_with(model: @puzzle, local: true, id: "input-task-2") do |f|
-  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-  -#     = f.submit '決定',id:"task-btn-2" , class:"task-modal__btn"
-
-  -# .task-modal__edit
-  -#   %p タスク3
-  -#   = form_with(model: @puzzle, local: true, id: "input-task-3") do |f|
-  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-  -#     = f.submit '決定',id:"task-btn-3" , class:"task-modal__btn"
-
-  -# .task-modal__edit
-  -#   %p タスク4
-  -#   = form_with(model: @puzzle, local: true, id: "input-task-4") do |f|
-  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-  -#     = f.submit '決定',id:"task-btn-4" , class:"task-modal__btn"
-
-  -# .task-modal__edit
-  -#   %p タスク5
-  -#   = form_with(model: @puzzle, local: true, id: "input-task-5") do |f|
-  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-  -#     = f.submit '決定',id:"task-btn-5" , class:"task-modal__btn"
-
-  -# .task-modal__edit
-  -#   %p タスク6
-  -#   = form_with(model: @puzzle, local: true, id: "input-task-6") do |f|
-  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-  -#     = f.submit '決定',id:"task-btn-6" , class:"task-modal__btn"
-
-  -# .task-modal__edit
-  -#   %p タスク7
-  -#   = form_with(model: @puzzle, local: true, id: "input-task-7") do |f|
-  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-  -#     = f.submit '決定',id:"task-btn-7" , class:"task-modal__btn"
-
-  -# .task-modal__edit
-  -#   %p タスク8
-  -#   = form_with(model: @puzzle, local: true, id: "input-task-8") do |f|
-  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-  -#     = f.submit '決定',id:"task-btn-8" , class:"task-modal__btn"
-
-  -# .task-modal__edit
-  -#   %p タスク9
-  -#   = form_with(model: @puzzle, local: true, id: "input-task-9") do |f|
-  -#     = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-  -#     = f.submit '決定',id:"task-btn-9" , class:"task-modal__btn"
 
 .task__index
   .task__index--unit1

--- a/app/views/puzzles/index.html.haml
+++ b/app/views/puzzles/index.html.haml
@@ -20,12 +20,12 @@
     .fas.fa-window-close.fa-lg#modal-close
 
 
-  - @puzzles.each do |puzzle|
-    .task-modal__edit
-      %p タスク1
-      = form_with(model: puzzle, url: user_puzzle_path, method: :patch) do |f|
-        = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
-        = f.submit '決定',id:"task-btn-1" , class:"task-modal__btn"
+  -# - @puzzles.each do |puzzle|
+  .task-modal__edit
+    %p タスク1
+    = form_with(model: @puzzle, url: user_puzzle_path, method: :patch) do |f|
+      = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
+      = f.submit '決定',id:"task-btn-1" , class:"task-modal__btn"
 
   -# .task-modal__edit
   -#   %p タスク2

--- a/app/views/puzzles/index.html.haml
+++ b/app/views/puzzles/index.html.haml
@@ -17,6 +17,8 @@
       %p タスクが入力されていません
     -else
       %p= @puzzles[0].task
+    .task__index--edit
+      = link_to "編集", edit_user_puzzle_path(current_user,@puzzles[0]), class: "task__index--edit--link"
     .round.position
       %input#checkbox.TL-btn{:type => "checkbox"}/
       %label{:for => "checkbox"}

--- a/app/views/puzzles/index.html.haml
+++ b/app/views/puzzles/index.html.haml
@@ -30,6 +30,8 @@
       %p タスクが入力されていません
     -else
       %p= @puzzles[1].task
+    .task__index--edit
+      = link_to "編集", edit_user_puzzle_path(current_user,@puzzles[1]), class: "task__index--edit--link"
     .round.position
       %input#checkbox2.TC-btn{:type => "checkbox"}/
       %label{:for => "checkbox2"}
@@ -41,6 +43,8 @@
       %p タスクが入力されていません
     -else
       %p= @puzzles[2].task
+    .task__index--edit
+      = link_to "編集", edit_user_puzzle_path(current_user,@puzzles[2]), class: "task__index--edit--link"
     .round.position
       %input#checkbox3.TR-btn{:type => "checkbox"}/
       %label{:for => "checkbox3"}
@@ -52,6 +56,8 @@
       %p タスクが入力されていません
     -else
       %p= @puzzles[3].task
+    .task__index--edit
+      = link_to "編集", edit_user_puzzle_path(current_user,@puzzles[3]), class: "task__index--edit--link"
     .round.position
       %input#checkbox4.CL-btn{:type => "checkbox"}/
       %label{:for => "checkbox4"}
@@ -63,6 +69,8 @@
       %p タスクが入力されていません
     -else
       %p= @puzzles[4].task
+    .task__index--edit
+      = link_to "編集", edit_user_puzzle_path(current_user,@puzzles[4]), class: "task__index--edit--link"
     .round.position
       %input#checkbox5.CC-btn{:type => "checkbox"}/
       %label{:for => "checkbox5"}
@@ -74,6 +82,8 @@
       %p タスクが入力されていません
     -else
       %p= @puzzles[5].task
+    .task__index--edit
+      = link_to "編集", edit_user_puzzle_path(current_user,@puzzles[5]), class: "task__index--edit--link"
     .round.position
       %input#checkbox6.CR-btn{:type => "checkbox"}/
       %label{:for => "checkbox6"}
@@ -85,6 +95,8 @@
       %p タスクが入力されていません
     -else
       %p= @puzzles[6].task
+    .task__index--edit
+      = link_to "編集", edit_user_puzzle_path(current_user,@puzzles[6]), class: "task__index--edit--link"
     .round.position
       %input#checkbox7.BL-btn{:type => "checkbox"}/
       %label{:for => "checkbox7"}
@@ -96,6 +108,8 @@
       %p タスクが入力されていません
     -else
       %p= @puzzles[7].task
+    .task__index--edit
+      = link_to "編集", edit_user_puzzle_path(current_user,@puzzles[7]), class: "task__index--edit--link"
     .round.position
       %input#checkbox8.BC-btn{:type => "checkbox"}/
       %label{:for => "checkbox8"}
@@ -107,6 +121,8 @@
       %p タスクが入力されていません
     -else
       %p= @puzzles[8].task
+    .task__index--edit
+      = link_to "編集", edit_user_puzzle_path(current_user,@puzzles[8]), class: "task__index--edit--link"
     .round.position
       %input#checkbox9.BR-btn{:type => "checkbox"}/
       %label{:for => "checkbox9"}

--- a/app/views/puzzles/index.html.haml
+++ b/app/views/puzzles/index.html.haml
@@ -23,7 +23,7 @@
   - @puzzles.each do |puzzle|
     .task-modal__edit
       %p タスク1
-      = form_for model: puzzle, url: user_puzzle_path do |f|
+      = form_with(model: puzzle, url: user_puzzle_path, method: :patch) do |f|
         = f.text_field :task, placeholder: "タスクを入力", class: "task-modal__input"
         = f.submit '決定',id:"task-btn-1" , class:"task-modal__btn"
 

--- a/db/migrate/20200502120353_change_column_default.rb
+++ b/db/migrate/20200502120353_change_column_default.rb
@@ -1,0 +1,5 @@
+class ChangeColumnDefault < ActiveRecord::Migration[5.2]
+  def change
+    change_column :puzzles, :task, :string, default: "タスクが入力されていません"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_19_061239) do
+ActiveRecord::Schema.define(version: 2020_05_02_120353) do
 
   create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2020_04_19_061239) do
     t.datetime "updated_at", null: false
     t.boolean "square", default: false, null: false
     t.bigint "user_id"
-    t.string "task"
+    t.string "task", default: "タスクが入力されていません"
     t.index ["user_id"], name: "index_puzzles_on_user_id"
   end
 


### PR DESCRIPTION
#What
ビューのみ作成していたタスクモーダルの削除。
タスク一覧の各タスクに編集ボタンを設置。
タスクパズル編集画面、機能の実装。

#Why
デフォルトでは「タスクが入力されていません」のままなので、9個それぞれを編集できるようにするため。